### PR TITLE
[CORE-6788] Ensure backend failure don't terminate the publishing process

### DIFF
--- a/tracing.cabal
+++ b/tracing.cabal
@@ -46,6 +46,7 @@ library
     , network >= 2.8
     , random >= 1.1
     , stm-lifted >= 2.5
+    , stm >= 2.5
     , text >= 1.2
     , time >= 1.8 && < 1.10
     , transformers >= 0.5


### PR DESCRIPTION
This PR mostly builds upon the opened draft PR on the original tracing repo (https://github.com/mtth/tracing/pull/9) to ensure that the library survives gracefully a failure to connect to the backend.

The main change is to use a bounded queue (reasonably sized) to store samples to be sent to the backend, and to have a logic to re-enqueue messages that could not be sent.

As a result:

- Exceptions to connect to the backend are properly silenced;
- When the connection can be reestablished, the missing messages are resent, so that no information should be lost.

I tested with the following dummy code:

```
{-# LANGUAGE OverloadedStrings #-}
{-# LANGUAGE FlexibleContexts #-}
module Main where

import Control.Monad (forever)
import Control.Monad.Base (MonadBase, liftBase)
import Control.Concurrent.Lifted (threadDelay)
import Monitor.Tracing
import Control.Monad.Trace.Class (rootSpanWith)
import qualified Monitor.Tracing.Zipkin as ZPK 

main :: IO ()
main = ZPK.with settings $ ZPK.run runner

settings :: ZPK.Settings
settings = 
  ZPK.defaultSettings
    { ZPK.settingsEndpoint =
      Just $
        ZPK.defaultEndpoint
          { ZPK.endpointService = Just "test"
          }
          , ZPK.settingsPublishPeriod = Just 1 -- second
    }   

runner :: (MonadBase IO m, MonadTrace m) => m ()
runner = rootSpanWith (ZPK.addInheritedTag "id" "1234") alwaysSampled "example" $
  forever $ do
    childSpan "wakeup" wakeup
    threadDelay 5000000

wakeup :: (MonadBase IO m, MonadTrace m) => m ()
wakeup = do
  liftBase . putStrLn $ "Woke up"
  threadDelay 3000000
  childSpan "subcall" doubleWakeup

doubleWakeup :: (MonadBase IO m, MonadTrace m) => m ()
doubleWakeup = liftBase . putStrLn $ "Double wake up"
```

I did some profiling on this to ensure this didn't introduce any leak.

With no connection loss, we seem to have quasi-constant space:
![no-loss-of-backend](https://github.com/scrive/tracing/assets/3382997/c7418eed-41d2-48d8-a671-7d346ed27793)

With a connection loss, oddly enough, there is a clear variation:
![loss-of-backend](https://github.com/scrive/tracing/assets/3382997/b778cd0b-a96c-4026-9efe-e61e6eed1a6f)

I understand the spike (the queue gets filled), I don't get why it gets way lower afterwards; at least it doesn't leak, I guess, but I'm still a bit puzzled by the result.

---
Edit after changes: now that I've switched to the SBQueue, the results are much closer to what I expected (though postscript did some odd things in rendering, apologies for the lack of readability).

With no loss, we have - again - constant space:

![tracer-test-no-loss](https://github.com/scrive/tracing/assets/3382997/053214e7-3b3f-4c6c-a70a-cb0ee15db181)

When losing the backend then replugging it, we observe a spike associated with the queue filling (though a very very long name in the key shrunk the graph, the spike followed by a return to normal is clearly observable):

![tracer-test-loss](https://github.com/scrive/tracing/assets/3382997/d3b9f783-affc-42b0-99d2-5883b111cc2f)

