### PR TITLE
Fix tests broken by retry on reading SBQueue

### DIFF
--- a/src/Monitor/Tracing/Local.hs
+++ b/src/Monitor/Tracing/Local.hs
@@ -34,11 +34,11 @@ collectSpanSamples actn = do
     samplesTC = spanSamples tracer
     pendingTV = pendingSpanCount tracer
   liftIO $ fix $ \loop -> do
-    (mbSample, pending) <- atomically $ (,) <$> readSBQueue samplesTC <*> readTVar pendingTV
+    (mbSample, pending) <- atomically $ (,) <$> readSBQueueOnce samplesTC <*> readTVar pendingTV
     case mbSample of
       (x:xs) -> mapM_ addSample (x:xs) >> loop
       [] | pending > 0 -> do
-        toAdd <- liftIO (atomically $ readSBQueue samplesTC)
+        toAdd <- liftIO (atomically $ readSBQueueOnce samplesTC)
         mapM_ addSample toAdd
         loop
       _ -> pure ()


### PR DESCRIPTION
Being somewhat ~stupid~ forgetful, I did forget to run tests before merging my previous PR. Though manual tests showed no issues, previous changes _did_ break the local tracer, for a simple reason: our implementation of `readSBQueue` retries until it finds something, which is fine when running in a fork, but breaks when operating in a main thread (with the infamous "thread blocked indefinitely in an MVar operation").
So I added a non-retrying version for this specific use-case (and fixed the tests).