### PR TITLE
Drop stm-lifted dependency

### DIFF
--- a/src/Monitor/Tracing/Local.hs
+++ b/src/Monitor/Tracing/Local.hs
@@ -7,7 +7,7 @@ module Monitor.Tracing.Local (
 
 import Control.Monad.Trace
 
-import Control.Concurrent.STM.Lifted (atomically, readTVar)
+import Control.Concurrent.STM (atomically, readTVar)
 import Control.Monad.Fix (fix)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Control (MonadBaseControl)

--- a/src/Monitor/Tracing/Zipkin.hs
+++ b/src/Monitor/Tracing/Zipkin.hs
@@ -45,10 +45,11 @@ import Control.Monad.Trace.Class
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Lifted (fork)
-import Control.Concurrent.STM.Lifted (atomically)
+import Control.Concurrent.STM (atomically)
 import Control.Exception (SomeException)
 import Control.Exception.Lifted (finally, try)
 import Control.Monad (forever, guard, unless, void)
+import Control.Monad.Base (liftBase)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.Aeson as JSON
@@ -75,7 +76,6 @@ import Data.Time.Clock.POSIX (POSIXTime)
 import Network.HTTP.Client (Manager, Request)
 import qualified Network.HTTP.Client as HTTP
 import Network.Socket (HostName, PortNumber)
-import Control.Monad.Base (liftBase)
 
 -- | 'Zipkin' creation settings.
 data Settings = Settings

--- a/tracing.cabal
+++ b/tracing.cabal
@@ -45,7 +45,6 @@ library
     , mtl >= 2.2
     , network >= 2.8
     , random >= 1.1
-    , stm-lifted >= 2.5
     , stm >= 2.5
     , text >= 1.2
     , time >= 1.8 && < 1.10
@@ -65,7 +64,7 @@ test-suite tracing-test
     , lifted-base >= 0.2.3
     , monad-control >= 1.0
     , mtl
-    , stm-lifted >= 2.5
+    , stm
     , text
     , tracing
   ghc-options: -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
_Warning: this is based upon https://github.com/scrive/tracing/pull/8, which should probably be merged first. If you want to review before the merge of the PR, I recommend considering only the second commit when reviewing._

As suggested by @arybczak, this PR removes the dependency upon `stm-lifted`, at the cost of sprinkling a bit of `liftBase` or `liftIO` here and there (I used `liftIO` in the tests to avoid adding a dependency to tests, but favoured `liftBase` elsewhere for the sake of using the most generalized definition, though I doubt we'll ever use something else than `IO` as base).