### PR TITLE
Make Trace a dynamically dispatched effect

### DIFF
--- a/tracing-effectful/src/Effectful/Trace.hs
+++ b/tracing-effectful/src/Effectful/Trace.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Effectful.Tracing
+module Effectful.Trace
     (
         -- * Effect
         Trace
@@ -10,19 +10,19 @@ module Effectful.Tracing
     ,   runNoTrace
 
         -- * Zipkin utilities
-    ,   runZipkinTracing
+    ,   runZipkinTrace
     ,   withZipkin
 
         -- * Reexport
     ,  module Monitor.Tracing
     ) where
 
+import Control.Monad.Catch (finally)
+import Control.Monad.Trace
+import Control.Monad.Trace.Class
 import Effectful
 import Effectful.Dispatch.Dynamic
 import Effectful.Reader.Static
-import Control.Monad.Trace
-import Control.Monad.Trace.Class
-import Control.Monad.Catch (finally)
 import Monitor.Tracing
 import Monitor.Tracing.Zipkin (Zipkin(zipkinTracer), Settings, new, publish)
 
@@ -72,8 +72,8 @@ withZipkin settings f = do
 -- | Runs a 'TraceT' action, sampling spans appropriately. Note that this method does not publish
 -- spans on its own; to do so, either call 'publish' manually or specify a positive
 -- 'settingsPublishPeriod' to publish in the background.
-runZipkinTracing :: (IOE :> es) => Zipkin -> Eff (Trace : es) a -> Eff es a
-runZipkinTracing zipkin = runTrace (zipkinTracer zipkin)
+runZipkinTrace :: (IOE :> es) => Zipkin -> Eff (Trace : es) a -> Eff es a
+runZipkinTrace zipkin = runTrace (zipkinTracer zipkin)
 
 -- | Orphan, canonical instance.
 instance Trace :> es => MonadTrace (Eff es) where

--- a/tracing-effectful/tracing-effectful.cabal
+++ b/tracing-effectful/tracing-effectful.cabal
@@ -28,7 +28,7 @@ common language
 
 library
   import:          language
-  exposed-modules: Effectful.Tracing
+  exposed-modules: Effectful.Trace
   build-depends:
     , base            <5
     , effectful-core  >=1.0.0.0 && <3.0.0.0

--- a/tracing-effectful/tracing-effectful.cabal
+++ b/tracing-effectful/tracing-effectful.cabal
@@ -20,6 +20,7 @@ common language
   default-extensions:
     DataKinds
     FlexibleContexts
+    GADTs
     KindSignatures
     LambdaCase
     TypeFamilies


### PR DESCRIPTION
After some thinking I decided that `Trace` should be dynamic since currently it has two interpretations crammed into it based on whether the `Scope` is there or not (another design flaw of the original library). I also renamed `Tracing` to `Trace` to keep naming consistent with TraceT and MonadTrace.

I also don't think `addSpanEntry` should do anything in the no-op handler.

EDIT: I'll rename `Effectful.Tracing` to `Effectful.Trace` before merging, I didn't do it yet because then GitHub generates a bad diff.